### PR TITLE
help command

### DIFF
--- a/bin/akamai-cloudlets.py
+++ b/bin/akamai-cloudlets.py
@@ -116,11 +116,20 @@ pass_config = click.make_pass_decorator(Config, ensure=True)
 @pass_config
 def cli(config, edgerc, section, account_key):
     '''
-    Akamai CLI for Cloudlets 1.1.1
+    Akamai CLI for Cloudlets 1.1.2
     '''
     config.edgerc = edgerc
     config.section = section
     config.account_key = account_key
+
+
+@cli.command()
+@click.pass_context
+def help(ctx):
+    '''
+    Show help information
+    '''
+    print(ctx.parent.get_help())
 
 
 @cli.command(short_help='List available cloudlets')

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ prettytable==0.7.2
 requests>=2.25.1,<3.0
 rich==13.3.3
 tabulate==0.9.0
-urllib3==1.26.5
+urllib3==1.26.18
 xlsxwriter==3.0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 chardet==3.0.4
 click==8.1.3
 edgegrid-python==1.2.1
+flake8==6.1.0
 openpyxl==3.1.2
 pandas==1.5.3
 pre-commit==3.3.3


### PR DESCRIPTION
Fix:
1. Make help command consistent with other akamai CLI, per #[wzagrajcz](https://github.com/akamai/cli-cloudlets/issues?q=is%3Aissue+is%3Aopen+author%3Awzagrajcz)
2. Bump urllib3 version
3. Minor version incorrectly display.  It should be  Akamai CLI for Cloudlets 1.1.2 not 1.1.1