### PR TITLE
Upgrade pandas and prettytable versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,9 @@ click==8.1.3
 edgegrid-python==1.3.1
 flake8==7.1.1
 openpyxl==3.1.2
-pandas==2.1.3
+pandas==2.2.2
 pre-commit==3.3.3
-prettytable==0.7.2
+prettytable==1.0.0
 requests>=2.25.1,<3.0
 rich==13.3.3
 tabulate==0.9.0


### PR DESCRIPTION
While building Docker images for cli-cloudlets ([repository link](https://git.source.akamai.com/projects/DEVEXP/repos/akamai-docker/)), we have observed an increase in both the build time and the size of the images.

before
akamai/cloudlets   amd64    270MB
akamai/cloudlets   arm64     315MB

after
akamai/cloudlets   amd64    247MB
akamai/cloudlets   arm64     242MB

To address this, we plan to use pre-built wheels. However, we encountered the following issues:

Missing Wheel for Prettytable 0.7.2:
The required wheels for Prettytable 0.7.2 are also unavailable.

No Wheels for Pandas 2.1.2:
The required wheels for Pandas 2.1.2 are also unavailable.

Solution:
This PR replaces Prettytable with version 1.0.0. Additionally, to utilize wheels, it's necessary to upgrade to Pandas 2.2.2.