### PR TITLE
security: update vulnerable Python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ prettytable==1.0.0
 requests>=2.25.1,<3.0
 rich==13.3.3
 tabulate==0.9.0
-urllib3==2.1.0
+urllib3>=2.6.0
 xlsxwriter==3.0.9


### PR DESCRIPTION
- Update urllib3 to >=2.6.0 (fixes CVE-2025-66471, CVE-2025-66418)
- Resolves all high/critical pip audit vulnerabilities